### PR TITLE
Add deprecation notice for TensorFlow model deployment to Connect

### DIFF
--- a/guides/deploy/rsconnect.qmd
+++ b/guides/deploy/rsconnect.qmd
@@ -4,9 +4,15 @@ aliases:
   - /deploy/rsconnect/
 ---
 
-In this tutorial you will learn how to deploy a TensorFlow model to [RStudio Connect](https://rstudio.com/products/connect/). RStudio Connect uses [TensorFlow
-Serving](https://github.com/tensorflow/serving) for performance but makes it
-much easier for R users to manage their deployment.
+::: callout-waring
+## Deprecation Notice
+
+Starting in [RStudio Connect 2022.09.0](https://docs.rstudio.com/connect/news/#rstudio-connect-2022090), TensorFlow model hosting is deprecated and will be removed in an upcoming release.
+Use an API framework like [Plumber](plumber.qmd), Flask, or FastAPI to create an HTTP API for your TensorFlow model.
+:::
+
+In this tutorial you will learn how to deploy a TensorFlow model to [RStudio Connect](https://rstudio.com/products/connect/).
+RStudio Connect uses [TensorFlow Serving](https://github.com/tensorflow/serving) for performance but makes it much easier for R users to manage their deployment.
 
 ## Building the model
 
@@ -28,8 +34,7 @@ mnist$test$x <- (mnist$test$x/255) %>%
 
 ```
 
-Now, we are going to define our Keras model, it will be a simple convolutional neural
-network.
+Now, we are going to define our Keras model, it will be a simple convolutional neural network.
 
 ```{r}
 model <- keras_model_sequential() %>%
@@ -62,8 +67,7 @@ model %>%
   )
 ```
 
-When we are happy with our model accuracy in the validation dataset we can `evaluate`
-the results on the test dataset with:
+When we are happy with our model accuracy in the validation dataset we can `evaluate` the results on the test dataset with:
 
 ```{r}
 model %>% evaluate(x = mnist$test$x, y = mnist$test$y, verbose = 0)
@@ -80,14 +84,13 @@ With the model built and saved we can now start building our plumber API file.
 
 ## Deployiong to RStudio Connect
 
-Once the model is saved to the SavedModel format, the model can be deployed with
-a single line of code:
+Once the model is saved to the SavedModel format, the model can be deployed with a single line of code:
 
 ```{r, eval = FALSE}
 rsconnect::deployTFModel("cnn-mnist/")
 ```
 
-When the deployment is complete you will be redirected to your browser with some
-instructions on how to call the REST endpoint:
+When the deployment is complete you will be redirected to your browser with some instructions on how to call the REST endpoint:
 
 ![](images/rsc.png)
+


### PR DESCRIPTION
September release deprecates support for TensorFlow model deployment in Connect

![Screen Shot 2022-09-14 at 5 02 06 PM](https://user-images.githubusercontent.com/4359210/190283393-cb42246f-f808-4a64-982c-3d64d6a0046f.png)

Sorry about the line break changes. Not sure what happened there. They weren't intentional.